### PR TITLE
Remove proxy configuration from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,3 @@
 #Thu Jul 21 11:19:13 BST 2016
 android.enableJetifier=true
 android.useAndroidX=true
-systemProp.http.proxyHost=192.168.100.99
-systemProp.http.proxyPort=808


### PR DESCRIPTION
This should be in local.properties. This breaks sync if there is no proxy.

_If your pull request is a translation update, then the title of this pull must contains 'string' or 'translation'_
