### PR TITLE
Ui fix

### DIFF
--- a/app/src/main/java/org/meowcat/edxposed/manager/AdvancedInstallerFragment.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/AdvancedInstallerFragment.java
@@ -61,7 +61,6 @@ public class AdvancedInstallerFragment extends Fragment {
         mTabLayout = view.findViewById(R.id.tab_layout);
 
         tabsAdapter = new TabsAdapter(getChildFragmentManager());
-        tabsAdapter.notifyDataSetChanged();
         mPager.setAdapter(tabsAdapter);
         mTabLayout.setupWithViewPager(mPager);
 
@@ -324,6 +323,7 @@ public class AdvancedInstallerFragment extends Fragment {
         private String newApkVersion = null;
         private String newApkLink = null;
         private String newApkChangelog = null;
+        private List<XposedTab> tabs = null;
         private boolean noZips = false;
 
         @Override
@@ -333,15 +333,10 @@ public class AdvancedInstallerFragment extends Fragment {
 
                 final JSONUtils.XposedJson xposedJson = new Gson().fromJson(originalJson, JSONUtils.XposedJson.class);
 
-                List<XposedTab> tabs = Stream.of(xposedJson.tabs)
+                tabs = Stream.of(xposedJson.tabs)
                         .filter(value -> value.sdks.contains(Build.VERSION.SDK_INT)).toList();
 
                 noZips = tabs.isEmpty();
-
-                for (XposedTab tab : tabs) {
-                    tabsAdapter.addFragment(tab.name, BaseAdvancedInstaller.newInstance(tab));
-                }
-
                 newApkVersion = xposedJson.apk.version;
                 newApkLink = xposedJson.apk.link;
                 newApkChangelog = xposedJson.apk.changelog;
@@ -359,6 +354,9 @@ public class AdvancedInstallerFragment extends Fragment {
             super.onPostExecute(result);
 
             try {
+                for (XposedTab tab : tabs) {
+                    tabsAdapter.addFragment(tab.name, BaseAdvancedInstaller.newInstance(tab));
+                }
                 tabsAdapter.notifyDataSetChanged();
 
                 if (!result) {
@@ -401,7 +399,7 @@ public class AdvancedInstallerFragment extends Fragment {
             addFragment(getString(R.string.status), new StatusInstallerFragment());
         }
 
-        void addFragment(String title, Fragment fragment) {
+        void addFragment(final String title, final Fragment fragment) {
             titles.add(title);
             listFragment.add(fragment);
         }

--- a/app/src/main/java/org/meowcat/edxposed/manager/StatusInstallerFragment.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/StatusInstallerFragment.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -51,6 +52,7 @@ public class StatusInstallerFragment extends Fragment {
     private static TextView mErrorTv;
     private static boolean isXposedInstalled = false;
     private TextView txtKnownIssue;
+    private Button btnKnownIssue;
 
     static void setError(boolean connectionFailed, boolean noSdks) {
         if (!connectionFailed && !noSdks) {
@@ -199,6 +201,7 @@ public class StatusInstallerFragment extends Fragment {
         mUpdateButton = v.findViewById(R.id.click_to_update);
 
         txtKnownIssue = v.findViewById(R.id.framework_known_issue);
+        btnKnownIssue = v.findViewById(R.id.framework_know_issue_detail);
 
         TextView txtInstallError = v.findViewById(R.id.framework_install_errors);
         View txtInstallContainer = v.findViewById(R.id.status_container);
@@ -381,9 +384,15 @@ public class StatusInstallerFragment extends Fragment {
             final String issueLinkFinal = issueLink;
             txtKnownIssue.setText(getString(R.string.install_known_issue, issueName));
             txtKnownIssue.setVisibility(View.VISIBLE);
-            txtKnownIssue.setOnClickListener(v -> NavUtil.startURL(getActivity(), issueLinkFinal));
+            if (issueLinkFinal != null) {
+                btnKnownIssue.setOnClickListener(v -> NavUtil.startURL(getActivity(), issueLinkFinal));
+                btnKnownIssue.setVisibility(View.VISIBLE);
+            } else {
+                btnKnownIssue.setVisibility(View.GONE);
+            }
         } else {
             txtKnownIssue.setVisibility(View.GONE);
+            btnKnownIssue.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/res/layout/status_installer.xml
+++ b/app/src/main/res/layout/status_installer.xml
@@ -89,6 +89,13 @@
                         android:textColor="@color/warning"
                         android:visibility="gone" />
 
+                    <Button
+                        android:id="@+id/framework_know_issue_detail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/install_known_issue_details"
+                        android:visibility="gone" />
+
                 </LinearLayout>
 
             </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -33,7 +33,6 @@
     <string name="install_warning_title">Dbej opatrnosti!</string>
     <string name="install_warning">V některých případech nemusí tvé zařízení po instalaci EdXposed již naběhnout.\n\nPokud ti nic neříkají pojmy \"soft brick\" či \"bootloop\" a pokud nevíš, jak se v podobné situaci zachovat, <b>NEINSTALUJ</b> EdXposed!\n\nV každém případě je vřele doporučeno mít aktuální zálohu zařízení.</string>
     <string name="dont_show_again">Již nezobrazovat</string>
-    <string name="install_known_issue">Zdá se, že existuje známý problém (\"%s\") s tvojí ROM. Instalace EdXposed nemusí fungovat, nebo může vést k závažným problémům. Pro podrobnosti o tomto problému stiskni zde.</string>
     <string name="installed_lollipop">EdXposed Framework je aktivní</string>
     <string name="installed_lollipop_inactive">EdXposed Framework je nainstalován, ale není aktivní\nProsím, zkontroluj log pro podrobnosti.</string>
     <string name="modules_updates_available">Aktualizace modulu k dispozici</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -28,7 +28,7 @@
     <string name="soft_reboot">Myk omstart</string>
     <string name="reboot">Omstart</string>
     <string name="areyousure">Er du sikker?</string>
-    <string name="phone_not_compatible">EdXposed er ikke kompatibel (enda) med 'Android SDK'-versjonen %1$d eller din prosessorarkitektur (%2$s)</string>
+    <string name="phone_not_compatible">EdXposed er ikke kompatibel (enda) med \'Android SDK\'-versjonen %1$d eller din prosessorarkitektur (%2$s)</string>
     <string name="reboot_failed">Omstart mislyktes. Vennligst bruk enhetens vanlige omstartsfunksjon</string>
     <string name="install_warning_title">Vær forsiktig!</string>
     <string name="install_warning">I noen tilfeller kan enheten din kanskje ikke starte opp etter å ha installert EdXposed.\n\nHvis du aldri har hørt om \"soft brick\" og \"bootloop\" før, eller at du ikke vet hvordan man henter seg inn fra en slik situasjon, <b>IKKE</b> installer eller bruk EdXposed!\n\nUansett er det høyst anbefalt å ha en nylig sikkerhetskopi klar.</string>
@@ -114,7 +114,7 @@
     <string name="support_modules_label">Støtte for moduler</string>
     <string name="support_modules_description">Klikk på enhver modul i modullisten og velg «%1$s».</string>
     <string name="support_framework_label">Framework/Manager-støtte</string>
-    <string name="support_faq_label">FAQ / kjente problemer/string>
+    <string name="support_faq_label">FAQ / kjente problemer</string>
     <string name="support_group_qq">QQ-gruppe: 855219808</string>
     <string name="support_group_telegram">Telegram-gruppe: @Code_of_MeowCat</string>
     <string name="support_donate_label">Donér</string>
@@ -281,7 +281,7 @@
     <string name="take_while_cannot_resore">Er du sikker på at du vil optimalisere alle apper?\n\nDette kan ta en stund, og KAN IKKE bli gjenopprettet\n\nTips: Du kan optimalisere bestemte apper i applisten</string>
     <string name="done">Ferdig!</string>
     <string name="verified_boot_deactivated">Verifisert Oppstart er skrudd av</string>
-    <string name="verified_boot_none">Klarte ikke å finne 'Verifisert Oppstart'-statusen</string>
+    <string name="verified_boot_none">Klarte ikke å finne \'Verifisert Oppstart\'-statusen</string>
     <string name="verified_boot_active">Verifisert Oppstart er aktiv</string>
     <string name="verified_boot_explanation">Verifisert Oppstart (dm-verity) hindrer enheten fra å starte opp dersom systempartisjonen har blitt endret på</string>
     <string name="ignore_chinese">Ignorer kinesiske tegn</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -33,7 +33,6 @@
     <string name="install_warning_title">Vær forsiktig!</string>
     <string name="install_warning">I noen tilfeller kan enheten din kanskje ikke starte opp etter å ha installert EdXposed.\n\nHvis du aldri har hørt om \"soft brick\" og \"bootloop\" før, eller at du ikke vet hvordan man henter seg inn fra en slik situasjon, <b>IKKE</b> installer eller bruk EdXposed!\n\nUansett er det høyst anbefalt å ha en nylig sikkerhetskopi klar.</string>
     <string name="dont_show_again">Ikke vis dette igjen</string>
-    <string name="install_known_issue">Det ser ut til å være et kjent problem (\"%s\")\nKlikk her for detaljer om problemet</string>
     <string name="installed_lollipop">EdXposed Framework er aktiv</string>
     <string name="installed_lollipop_inactive">EdXposed Framework er installert, men er ikke aktiv\nSjekk loggføringen for detaljer</string>
     <string name="modules_updates_available">Moduloppdatering(er) er tilgjengelig(e)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,7 +33,6 @@
     <string name="install_warning_title">Будьте осторожны!</string>
     <string name="install_warning">В некоторых случаях устройство может не загрузиться после установки EdXposed.\nЕсли вы не знаете, что означают слова «soft brick» и «bootloop» (кирпич и бутлуп), и не знаете, как восстановить систему, <b>НЕ</b> устанавливайте и не используйте EdXposed!\nИ даже если уверены в себе, не забудьте сделать резервную копию системы."</string>
     <string name="dont_show_again">Больше не показывать это сообщение</string>
-    <string name="install_known_issue">Похоже, присутствует известная проблема (\"%s\").\nНажмите здесь для дополнительной информации</string>
     <string name="installed_lollipop">EdXposed Framework активирован!</string>
     <string name="installed_lollipop_inactive">EdXposed Framework установлен, но не активирован. Проверьте логи для подробностей</string>
     <string name="modules_updates_available">Доступны обновления модуля</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -33,7 +33,6 @@
     <string name="install_warning_title">请小心！</string>
     <string name="install_warning">某些情况下, 您的设备可能会在安装 EdXposed 过后变得无法正常启动\n\n如果您先前从未听说过「软变砖」或「无限重启」, 又或者您不知道如何从这些情况中恢复手机, 那么请"<b>不要</b>"安装或使用 EdXposed！\n\n无论如何, 都强烈建议您做好近期的数据备份</string>
     <string name="dont_show_again">不再提示</string>
-    <string name="install_known_issue">发现问题(\"%s\")\n点击这里来了解详情</string>
     <string name="installed_lollipop">EdXposed 框架已激活</string>
     <string name="installed_lollipop_inactive">EdXposed 框架已安装, 但尚未激活\n请查看日志以了解详情</string>
     <string name="modules_updates_available">有模块更新可用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -33,7 +33,8 @@
     <string name="install_warning_title">請小心！</string>
     <string name="install_warning">某些情況下，您的裝置可能會在安裝 EdXposed 過後無法正常啟動。\n\n如果您先前從未聽說過「軟變磚(Soft Brick)」或「無限重新啟動(Bootloop)」，又或者您不知道如何從這些情況中恢復手機，那麼請"<b>不要</b>"安裝 EdXposed！\n\n無論如何，我們都強烈建議您做好近期的資料備份。</string>
     <string name="dont_show_again">不再提示</string>
-    <string name="install_known_issue">EdXposed 與您的裝置之間似乎存在已知的問題（「%s」）。這可能將導致 EdXposed 無法被安裝或是更為嚴重的問題。點選這裡來了解詳細情形。</string>
+    <string name="install_known_issue">發現已知的問題：\n「%s」\n\n這可能將導致 EdXposed 動作錯誤或無法使用。</string>
+    <string name="install_known_issue_details">詳細資訊…</string>
     <string name="installed_lollipop">EdXposed 框架已啟用</string>
     <string name="installed_lollipop_inactive">EdXposed 框架已安裝，但尚未啟用\n請檢視日誌以瞭解詳細情形。</string>
     <string name="modules_updates_available">有模組更新可用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,8 @@
     <string name="install_warning_title">Be careful!</string>
     <string name="install_warning">In some cases, your device might no longer boot after installing EdXposed.\n\nIf you never heard about \"soft brick\" and \"bootloop\" before or if you don\'t know how to recover from such a situation, do <b>NOT</b> install or use EdXposed!\n\nIn any case, having a recent backup is highly recommended.</string>
     <string name="dont_show_again">Don\'t show this again</string>
-    <string name="install_known_issue">There seems to be a known issue (\"%s\")\nClick here for details about the issue</string>
+    <string name="install_known_issue">There seems to be a known issue:\n\"%s\"\n\nThis may render EdXposed malfunction or unusable.</string>
+    <string name="install_known_issue_details">Details…</string>
     <string name="installed_lollipop">EdXposed Framework is active</string>
     <string name="installed_lollipop_inactive">EdXposed Framework is installed, but not active\nPlease check the logs for details</string>
     <string name="modules_updates_available">Module update(s) are available</string>


### PR DESCRIPTION
1. escape various unescaped single-quote in `nb` translation (so it compiles...)
2. current known-issue message indicates you to click on a `TextView` to open up the remote link (in a browser), use a `Button` for that instead. also, don't show the button when there's actually no URL to "goto".
3. fix potential crash when updating the backed data in the `TabsAdapter`. this rarely happens, but it did happen on me a few (really few) times.
