### PR TITLE
Improve detection for LineageOS based ROM

### DIFF
--- a/app/src/main/java/org/meowcat/edxposed/manager/StatusInstallerFragment.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/StatusInstallerFragment.java
@@ -464,7 +464,7 @@ public class StatusInstallerFragment extends Fragment {
         } else if (new File("/system/framework/flyme-framework.jar").exists() || new File("/system/framework/flyme-res").exists() || new File("/system/framework/flyme-telephony-common.jar").exists()) {
             manufacturer += "(Flyme)";
         } else if (new File("/system/framework/org.lineageos.platform-res.apk").exists() || new File("/system/framework/org.lineageos.platform.jar").exists()) {
-            manufacturer += "(Lineage OS)";
+            manufacturer += "(Lineage OS Based ROM)";
         }
         return manufacturer;
     }


### PR DESCRIPTION
Not only LineageOS will use Lineage SDK, ROMs based on it will use it too.

_If your pull request is a translation update, then the title of this pull must contains 'string' or 'translation'_
