### PR TITLE
StrictMode DiskReadViolation fix

### DIFF
--- a/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
@@ -70,8 +70,8 @@ public class Enhancement implements IXposedHookLoadPackage {
             final File listFile = new File(String.format("/data/user_de/%s/%s/conf/enabled_modules.list", user, APPLICATION_ID));
             List<String> list = new ArrayList<>();
             try {
-                FileReader fileReader = new FileReader(listFile);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
+                final FileReader fileReader = new FileReader(listFile);
+                final BufferedReader bufferedReader = new BufferedReader(fileReader);
                 String str;
                 while ((str = bufferedReader.readLine()) != null) {
                     list.add(str);

--- a/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
@@ -79,7 +79,7 @@ public class Enhancement implements IXposedHookLoadPackage {
                 bufferedReader.close();
                 fileReader.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                XposedBridge.log(e);
             }
             modulesList = list;
             return list;

--- a/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
@@ -37,7 +37,7 @@ public class Enhancement implements IXposedHookLoadPackage {
 
     private static final String LEGACY_INSTALLER = "de.robv.android.xposed.installer";
 
-    private static final List HIDE_WHITE_LIST = Arrays.asList( // TODO: more whitelist packages
+    private static final List<String> HIDE_WHITE_LIST = Arrays.asList( // TODO: more whitelist packages
             APPLICATION_ID, // Whitelist or crash
             "com.android.providers.downloads", // For download modules
             "com.android.providers.downloads.ui",
@@ -49,7 +49,7 @@ public class Enhancement implements IXposedHookLoadPackage {
             "eu.chainfire.supersu"
     ); // UserHandle.isCore(uid) will auto pass
 
-    private static List modulesList = null;
+    private static List<String> modulesList = null;
 
     private static boolean getFlagState(int user, String flag) {
         final StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
@@ -60,7 +60,7 @@ public class Enhancement implements IXposedHookLoadPackage {
         }
     }
 
-    private static List getModulesList(int user) {
+    private static List<String> getModulesList(int user) {
         if (modulesList != null) {
             return modulesList;
         }

--- a/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageInfo;
 import android.os.Binder;
 import android.os.Build;
 import android.os.StrictMode;
+import android.os.UserHandle;
 
 import androidx.annotation.Keep;
 
@@ -46,7 +47,7 @@ public class Enhancement implements IXposedHookLoadPackage {
             "com.android.permissioncontroller", // For permissions grant
             "com.topjohnwu.magisk", // For superuser root grant
             "eu.chainfire.supersu"
-    ); // System server (uid <= 1000) will auto pass
+    ); // UserHandle.isCore(uid) will auto pass
 
     private static List modulesList = null;
 
@@ -111,7 +112,8 @@ public class Enhancement implements IXposedHookLoadPackage {
                         boolean isXposedModule = false;
                         final String[] packages =
                                 (String[]) XposedHelpers.callMethod(param.thisObject, "getPackagesForUid", packageUid);
-                        if (packages == null || packages.length == 0 || packageUid <= 1000) {
+                        if (packages == null || packages.length == 0 ||
+                                (boolean) XposedHelpers.callStaticMethod(UserHandle.class, "isCore", packageUid)) {
                             return;
                         }
                         for (String packageName : packages) {
@@ -160,7 +162,8 @@ public class Enhancement implements IXposedHookLoadPackage {
                         boolean isXposedModule = false;
                         final String[] packages =
                                 (String[]) XposedHelpers.callMethod(param.thisObject, "getPackagesForUid", packageUid);
-                        if (packages == null || packages.length == 0 || packageUid <= 1000) {
+                        if (packages == null || packages.length == 0 ||
+                                (boolean) XposedHelpers.callStaticMethod(UserHandle.class, "isCore", packageUid)) {
                             return;
                         }
                         for (String packageName : packages) {
@@ -209,7 +212,8 @@ public class Enhancement implements IXposedHookLoadPackage {
                         boolean isXposedModule = false;
                         final String[] packages =
                                 (String[]) XposedHelpers.callMethod(param.thisObject, "getPackagesForUid", packageUid);
-                        if (packages == null || packages.length == 0 || packageUid <= 1000) {
+                        if (packages == null || packages.length == 0 ||
+                                (boolean) XposedHelpers.callStaticMethod(UserHandle.class, "isCore", packageUid)) {
                             return;
                         }
                         for (String packageName : packages) {
@@ -249,7 +253,8 @@ public class Enhancement implements IXposedHookLoadPackage {
                         boolean isXposedModule = false;
                         final String[] packages =
                                 (String[]) XposedHelpers.callMethod(param.thisObject, "getPackagesForUid", packageUid);
-                        if (packages == null || packages.length == 0 || packageUid <= 1000) {
+                        if (packages == null || packages.length == 0 ||
+                                (boolean) XposedHelpers.callStaticMethod(UserHandle.class, "isCore", packageUid)) {
                             return;
                         }
                         for (String packageName : packages) {

--- a/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/xposed/Enhancement.java
@@ -17,6 +17,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
@@ -27,6 +28,7 @@ import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
+import static java.util.Collections.binarySearch;
 import static org.meowcat.edxposed.manager.BuildConfig.APPLICATION_ID;
 
 @Keep
@@ -50,6 +52,10 @@ public class Enhancement implements IXposedHookLoadPackage {
     ); // UserHandle.isCore(uid) will auto pass
 
     private static List<String> modulesList = null;
+
+    static {
+        Collections.sort(HIDE_WHITE_LIST);
+    }
 
     private static boolean getFlagState(int user, String flag) {
         final StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
@@ -81,6 +87,7 @@ public class Enhancement implements IXposedHookLoadPackage {
             } catch (IOException e) {
                 XposedBridge.log(e);
             }
+            Collections.sort(list);
             modulesList = list;
             return list;
         } finally {
@@ -117,10 +124,10 @@ public class Enhancement implements IXposedHookLoadPackage {
                             return;
                         }
                         for (String packageName : packages) {
-                            if (HIDE_WHITE_LIST.contains(packageName)) {
+                            if (binarySearch(HIDE_WHITE_LIST, packageName) >= 0) {
                                 return;
                             }
-                            if (getModulesList(userId).contains(packageName)) {
+                            if (binarySearch(getModulesList(userId), packageName) >= 0) {
                                 isXposedModule = true;
                                 break;
                             }
@@ -167,10 +174,10 @@ public class Enhancement implements IXposedHookLoadPackage {
                             return;
                         }
                         for (String packageName : packages) {
-                            if (HIDE_WHITE_LIST.contains(packageName)) {
+                            if (binarySearch(HIDE_WHITE_LIST, packageName) >= 0) {
                                 return;
                             }
-                            if (getModulesList(userId).contains(packageName)) {
+                            if (binarySearch(getModulesList(userId), packageName) >= 0) {
                                 isXposedModule = true;
                                 break;
                             }
@@ -217,10 +224,10 @@ public class Enhancement implements IXposedHookLoadPackage {
                             return;
                         }
                         for (String packageName : packages) {
-                            if (HIDE_WHITE_LIST.contains(packageName)) {
+                            if (binarySearch(HIDE_WHITE_LIST, packageName) >= 0) {
                                 return;
                             }
-                            if (getModulesList(userId).contains(packageName)) {
+                            if (binarySearch(getModulesList(userId), packageName) >= 0) {
                                 isXposedModule = true;
                                 break;
                             }
@@ -258,10 +265,10 @@ public class Enhancement implements IXposedHookLoadPackage {
                             return;
                         }
                         for (String packageName : packages) {
-                            if (HIDE_WHITE_LIST.contains(packageName)) {
+                            if (binarySearch(HIDE_WHITE_LIST, packageName) >= 0) {
                                 return;
                             }
-                            if (getModulesList(userId).contains(packageName)) {
+                            if (binarySearch(getModulesList(userId), packageName) >= 0) {
                                 isXposedModule = true;
                                 break;
                             }


### PR DESCRIPTION
Sometimes some app is having really strict access policy (ie. google search box).
we temporarily allow disk read when reading the flags.

_If your pull request is a translation update, then the title of this pull must contains 'string' or 'translation'_
