### PR TITLE
Update the way to kill the log catcher.

### DIFF
--- a/app/src/main/java/org/meowcat/edxposed/manager/SettingsFragment.java
+++ b/app/src/main/java/org/meowcat/edxposed/manager/SettingsFragment.java
@@ -530,7 +530,7 @@ public class SettingsFragment extends BasePreferenceFragment implements Preferen
             new Runnable() {
                 @Override
                 public void run() {
-                    BaseFragment.areYouSure(requireActivity(), getString(R.string.settings_summary_stop_log), (d, w) -> Shell.su("kill $(cat " + mVerboseLogProcessID.getAbsolutePath() + ")").exec(), (d, w) -> {
+                    BaseFragment.areYouSure(requireActivity(), getString(R.string.settings_summary_stop_log), (d, w) -> Shell.su("pkill -P $(cat " + mVerboseLogProcessID.getAbsolutePath() + ")").exec(), (d, w) -> {
                     });
                 }
             };
@@ -538,7 +538,7 @@ public class SettingsFragment extends BasePreferenceFragment implements Preferen
             new Runnable() {
                 @Override
                 public void run() {
-                    BaseFragment.areYouSure(requireActivity(), getString(R.string.settings_summary_stop_log), (d, w) -> Shell.su("kill $(cat " + mModulesLogProcessID.getAbsolutePath() + ")").exec(), (d, w) -> {
+                    BaseFragment.areYouSure(requireActivity(), getString(R.string.settings_summary_stop_log), (d, w) -> Shell.su("pkill -P $(cat " + mModulesLogProcessID.getAbsolutePath() + ")").exec(), (d, w) -> {
                     });
                 }
             };


### PR DESCRIPTION
Background: [this pull request](https://github.com/ElderDrivers/EdXposed/pull/575) in EdXposed.

If the above pull request is merged, the way to kill the log catcher will be changed. It is related to two functions in EdXposed Manager's source code. So we'd better modify it together, although it seems that the two functions are useless now (corresponding preferences are commented out).