### PR TITLE
Support JDK14 with Gradle-6.3 & Update gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,19 +36,19 @@ android {
 
 dependencies {
     //noinspection GradleDependency TODO: UI bug
-    implementation "com.google.android.material:material:1.0.0"
+    implementation "com.google.android.material:material:1.3.0-alpha02"
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation "androidx.browser:browser:1.2.0"
-    implementation "androidx.preference:preference:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.2.0-alpha01"
-    implementation "androidx.fragment:fragment:1.2.3"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "androidx.browser:browser:1.3.0-alpha05"
+    implementation "androidx.preference:preference:1.1.1"
+    implementation "androidx.recyclerview:recyclerview:1.2.0-alpha05"
+    implementation "androidx.fragment:fragment:1.3.0-alpha07"
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-rc1'
     implementation 'com.afollestad.material-dialogs:commons:0.9.0.2'
     implementation 'com.github.mtotschnig:StickyListHeaders:2.7.1'
     implementation "com.github.topjohnwu.libsu:busybox:2.5.0"
-    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
-    implementation 'com.annimon:stream:1.2.0'
+    implementation 'com.annimon:stream:1.2.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     compileOnly 'de.robv.android.xposed:api:82'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:commons:0.9.0.2'
     implementation 'com.github.mtotschnig:StickyListHeaders:2.7.1'
     implementation "com.github.topjohnwu.libsu:busybox:2.5.0"
-    implementation 'com.squareup.picasso:picasso:2.8'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
     implementation 'com.annimon:stream:1.2.1'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
`Could not initialize class org.codehaus.groovy.reflection.ReflectionCache` will be thrown when OpenJDK-14 is compiled with Gradle-6.1.1 